### PR TITLE
Support type inference for `oneEvent`

### DIFF
--- a/source/demo/background.ts
+++ b/source/demo/background.ts
@@ -12,6 +12,13 @@ oneEvent(chrome.tabs.onCreated).then(() => {
 	console.log('Tab created');
 });
 
+oneEvent(chrome.tabs.onMoved, (tabId, moveInfo) => {
+	console.log('Should handle event?', {tabId, moveInfo});
+	return Boolean(tabId % 5);
+}).then(() => {
+	console.log('Tab moved');
+});
+
 const httpsOnlyFilter = (tab: chrome.tabs.Tab) => Boolean(tab.pendingUrl?.startsWith('https'));
 oneEvent(
 	chrome.tabs.onCreated,

--- a/source/one-event.test.ts
+++ b/source/one-event.test.ts
@@ -1,5 +1,6 @@
 import {chrome} from 'jest-chrome';
-import {describe, it, vi, expect, beforeEach} from 'vitest';
+import {describe, it, vi, expect, beforeEach, expectTypeOf} from 'vitest';
+import {type Cookies, type Runtime} from 'jest-chrome/types/jest-chrome.js';
 import {oneEvent} from './one-event.js';
 
 function helloFromTheOtherSide(greeting = 'hello') {
@@ -43,5 +44,25 @@ describe('oneEvent', () => {
 		helloFromTheOtherSide('sup');
 
 		await expect(eventPromise).not.toBePending();
+	});
+
+	it('it should resolve original event\'s parameters', () => {
+		void oneEvent(chrome.tabs.onMoved, (tabId, moveInfo) => {
+			expectTypeOf(tabId).toEqualTypeOf<number>();
+			expectTypeOf(moveInfo).toEqualTypeOf<chrome.tabs.TabMoveInfo>();
+			return true;
+		});
+
+		void oneEvent(chrome.runtime.onMessage, (message, sender, sendResponse) => {
+			expectTypeOf(message).toEqualTypeOf<any>();
+			expectTypeOf(sender).toEqualTypeOf<Runtime.MessageSender>();
+			expectTypeOf(sendResponse).toEqualTypeOf<(response?: any) => void>();
+			return true;
+		});
+
+		void oneEvent(chrome.cookies.onChanged, changeInfo => {
+			expectTypeOf(changeInfo).toEqualTypeOf<Cookies.CookieChangeInfo>();
+			return true;
+		});
 	});
 });

--- a/source/one-event.ts
+++ b/source/one-event.ts
@@ -4,12 +4,13 @@ type RemovableEvent<T = (...args: unknown[]) => unknown> = {
 };
 
 export async function oneEvent<
-	Event extends RemovableEvent,
-	Filter extends (..._arguments: any[]) => boolean,
+	Event extends RemovableEvent<(...args: any[]) => void>,
+	EventParameters extends Parameters<Parameters<Event['addListener']>[0]>[0],
+	Filter extends (parameters: EventParameters) => boolean,
 >(event: Event, filter?: Filter): Promise<void> {
 	await new Promise<void>(resolve => {
-		const listener = (..._arguments: unknown[]) => {
-			if (!filter || filter(..._arguments)) {
+		const listener = (parameters: EventParameters) => {
+			if (!filter || filter(parameters)) {
 				resolve();
 				event.removeListener(listener);
 			}

--- a/source/one-event.ts
+++ b/source/one-event.ts
@@ -3,14 +3,17 @@ type RemovableEvent<T = (...args: unknown[]) => unknown> = {
 	addListener(callback: T): void;
 };
 
+type EventParameters<Event extends RemovableEvent<(...args: any[]) => void>> = Parameters<Parameters<Event['addListener']>[0]>;
+
 export async function oneEvent<
 	Event extends RemovableEvent<(...args: any[]) => void>,
-	EventParameters extends Parameters<Parameters<Event['addListener']>[0]>[0],
-	Filter extends (parameters: EventParameters) => boolean,
->(event: Event, filter?: Filter): Promise<void> {
+>(
+	event: Event,
+	filter?: (...parameters: EventParameters<Event>) => boolean,
+): Promise<void> {
 	await new Promise<void>(resolve => {
-		const listener = (parameters: EventParameters) => {
-			if (!filter || filter(parameters)) {
+		const listener = (parameters: EventParameters<Event>) => {
+			if (!filter || filter(...parameters)) {
 				resolve();
 				event.removeListener(listener);
 			}

--- a/source/one-event.ts
+++ b/source/one-event.ts
@@ -1,12 +1,16 @@
+type AnyFunction = (...parameters: any[]) => void;
+
 type RemovableEvent<T = (...args: unknown[]) => unknown> = {
 	removeListener(callback: T): void;
 	addListener(callback: T): void;
 };
 
-type EventParameters<Event extends RemovableEvent<(...args: any[]) => void>> = Parameters<Parameters<Event['addListener']>[0]>;
+type EventParameters
+	<Event extends RemovableEvent<AnyFunction>> =
+		Parameters<Parameters<Event['addListener']>[0]>;
 
 export async function oneEvent<
-	Event extends RemovableEvent<(...parameters: any[]) => void>,
+	Event extends RemovableEvent<AnyFunction>,
 >(
 	event: Event,
 	filter?: (...parameters: EventParameters<Event>) => boolean,

--- a/source/one-event.ts
+++ b/source/one-event.ts
@@ -12,13 +12,13 @@ export async function oneEvent<
 	filter?: (...parameters: EventParameters<Event>) => boolean,
 ): Promise<void> {
 	await new Promise<void>(resolve => {
-		const listener = (parameters: EventParameters<Event>) => {
+		const listener = (...parameters: EventParameters<Event>) => {
 			if (!filter || filter(...parameters)) {
 				resolve();
-				event.removeListener(listener);
+				event.removeListener(listener as VoidCallback);
 			}
 		};
 
-		event.addListener(listener);
+		event.addListener(listener as VoidCallback);
 	});
 }

--- a/source/one-event.ts
+++ b/source/one-event.ts
@@ -6,19 +6,20 @@ type RemovableEvent<T = (...args: unknown[]) => unknown> = {
 type EventParameters<Event extends RemovableEvent<(...args: any[]) => void>> = Parameters<Parameters<Event['addListener']>[0]>;
 
 export async function oneEvent<
-	Event extends RemovableEvent<(...args: any[]) => void>,
+	Event extends RemovableEvent<(...parameters: any[]) => void>,
 >(
 	event: Event,
 	filter?: (...parameters: EventParameters<Event>) => boolean,
 ): Promise<void> {
 	await new Promise<void>(resolve => {
-		const listener = (...parameters: EventParameters<Event>) => {
+		// TODO: VoidFunction should not be necessary, it's equivalent to using "any"
+		const listener: VoidFunction = (...parameters: EventParameters<Event>) => {
 			if (!filter || filter(...parameters)) {
 				resolve();
-				event.removeListener(listener as VoidCallback);
+				event.removeListener(listener);
 			}
 		};
 
-		event.addListener(listener as VoidCallback);
+		event.addListener(listener);
 	});
 }


### PR DESCRIPTION
Support Type inference for function: oneEvent()

The `RemovableEvent` can be `chrome`'s Event or `jest-chrome`'s Event.
So union these Event type and intersection `RemovableEvent`

Can more specify `RemovableEvent`'s generic to `<T = (...args: any[]) => void>`, But It is not seriously important for using api.