### PR TITLE
`onExtensionStart` - Run even when uncertain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "webext-events",
 			"version": "2.1.0",
 			"license": "MIT",
+			"dependencies": {
+				"webext-detect-page": "^5.0.0"
+			},
 			"devDependencies": {
 				"@parcel/config-webextension": "^2.10.3",
 				"@sindresorhus/tsconfig": "^5.0.0",
@@ -13894,6 +13897,17 @@
 			"resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
 			"integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
 			"dev": true
+		},
+		"node_modules/webext-detect-page": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-5.0.0.tgz",
+			"integrity": "sha512-ptkUyczkFOWKPfc1lPKptb3DkfK0FJB5f+nLwiNrWX2by1uo8nZdCdCu/92J1u+5Z65oPWd1s63orc8ojPbnOw==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
 		},
 		"node_modules/webidl-conversions": {
 			"version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
 	},
 	"webExt": {
 		"sourceDir": ".built/demo"
+	},
+	"dependencies": {
+		"webext-detect-page": "^5.0.0"
 	}
 }


### PR DESCRIPTION
Add support for:

- MV2 background scripts on Chrome: runs once ✅ 
- MV2 event pages on Chrome: runs at least once ⚠️
- anywhere without `storage` permission: runs at least once ⚠️