### PR TITLE
`onExtensionStart`: Add Firefox support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"webext-detect-page": "^5.0.0"
+				"webext-detect-page": "^5.0.1"
 			},
 			"devDependencies": {
 				"@parcel/config-webextension": "^2.10.3",
@@ -13899,9 +13899,9 @@
 			"dev": true
 		},
 		"node_modules/webext-detect-page": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-5.0.0.tgz",
-			"integrity": "sha512-ptkUyczkFOWKPfc1lPKptb3DkfK0FJB5f+nLwiNrWX2by1uo8nZdCdCu/92J1u+5Z65oPWd1s63orc8ojPbnOw==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-5.0.1.tgz",
+			"integrity": "sha512-HizogkTmviA5qA1yODwewzz4ETSc+N9bYrK6pEVIAP2kAG139Sg+3DOJixRnFYl2gFVZn4PBReDZhgmFOEVbeg==",
 			"engines": {
 				"node": ">=18"
 			},

--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
 		"sourceDir": ".built/demo"
 	},
 	"dependencies": {
-		"webext-detect-page": "^5.0.0"
+		"webext-detect-page": "^5.0.1"
 	}
 }

--- a/source/on-extension-start.md
+++ b/source/on-extension-start.md
@@ -22,9 +22,9 @@ onExtensionStart.addListener(listener);
 
 ## Compatibility
 
-- Chrome: 112+ (MV3 only)
+- Chrome: 112+ (no MV2 Event Pages support)
 - Safari: 16.4
-- Firefox: no
+- Firefox: 115
 
 ## Permissions
 
@@ -34,4 +34,4 @@ onExtensionStart.addListener(listener);
 
 - background worker
 - background page
-- event page
+- event page (not in Chrome)

--- a/source/on-extension-start.ts
+++ b/source/on-extension-start.ts
@@ -5,6 +5,9 @@ const event = new EventTarget();
 let hasRun = false;
 let hasListeners = false;
 
+// @ts-expect-error No need to load `browser` types yet
+const browserStorage = globalThis.browser?.storage as typeof chrome.storage ?? chrome.storage;
+
 async function runner() {
 	hasRun = true;
 
@@ -18,7 +21,7 @@ async function runner() {
 		return;
 	}
 
-	if (!chrome.storage?.session) {
+	if (!browserStorage?.session) {
 		if (isChrome() && chrome.runtime.getManifest().manifest_version === 2) {
 			console.warn('onExtensionStart is unable to determine whether it’s being run for the first time on MV2 Event Pages in Chrome. It will run the listeners anyway.');
 		} else {
@@ -29,12 +32,12 @@ async function runner() {
 		return;
 	}
 
-	const storage = await chrome.storage.session.get(storageKey);
+	const storage = await browserStorage.session.get(storageKey);
 	if (storageKey in storage) {
 		return;
 	}
 
-	await chrome.storage.session.set({[storageKey]: true});
+	await browserStorage.session.set({[storageKey]: true});
 	event.dispatchEvent(new Event('extension-start'));
 }
 


### PR DESCRIPTION
Tested:

- MV3 worker: ❌ Firefox won't load it
- MV3 script: ✅ runs once
- MV3 event page: ⚠️ not supported by Firefox, detected as ✅  script
	- Fixed in https://github.com/fregante/webext-detect-page/pull/29
- MV2 script: ✅ runs once
- MV2 event page: ✅ runs once